### PR TITLE
correct a couple of small typos

### DIFF
--- a/00d_r_data-structure-index.Rmd
+++ b/00d_r_data-structure-index.Rmd
@@ -153,9 +153,9 @@ str(sequence_example)
 ```
 
 The somewhat cryptic output from this command indicates the basic data type
-found in this vector - in this case `chr`, character; an indication of the
+found in this vector - in this case `int`, integer; an indication of the
 number of things in the vector - actually, the indexes of the vector, in this
-case `[1:3]`; and a few examples of what's actually in the vector - in this case
+case `[1:10]`; and a few examples of what's actually in the vector - in this case
 empty character strings. If we similarly do
 
 

--- a/00e_indexing_subsetting.Rmd
+++ b/00e_indexing_subsetting.Rmd
@@ -88,7 +88,7 @@ x[c(-1, -5)]  # or x[-c(1,5)]
 
 <div class="alert alert-warning">
 
-In general, e aware that the result of subsetting using indices could change if the vector is reordered. 
+In general, be aware that the result of subsetting using indices could change if the vector is reordered. 
 
 </div>
 
@@ -183,7 +183,7 @@ x[names(x) != c("a","c")]
 
 R did *something*, but it gave us a warning that we ought to pay attention to - and it apparently *gave us the wrong answer* (the `"c"` element is still included in the vector)!
 
-This happens because we are trying to compare two vectors (`names(x)` and `c("a","c")`) and comparison operators are automatically vectorised in such a case. So in effect, R is comparing `"a"` in `names(x)` to `"a"` in `c("a","c")` and returning `FALSE` (ie `"a" != "a" = FALSE`), then `"b"` in `names(x)` to `"c"` in `c("a","c")` and returning `TRUE`. What happens with `"c"` in `names(x)` is R recuycles the comparison vector `c("a","c")` and starts again with `"a"`. `"c"` is not equal to `"a"` so `"a" != "c"` returns `TRUE` and the element is kept.
+This happens because we are trying to compare two vectors (`names(x)` and `c("a","c")`) and comparison operators are automatically vectorised in such a case. So in effect, R is comparing `"a"` in `names(x)` to `"a"` in `c("a","c")` and returning `FALSE` (ie `"a" != "a" = FALSE`), then `"b"` in `names(x)` to `"c"` in `c("a","c")` and returning `TRUE`. What happens with `"c"` in `names(x)` is R recycles the comparison vector `c("a","c")` and starts again with `"a"`. `"c"` is not equal to `"a"` so `"a" != "c"` returns `TRUE` and the element is kept.
 
 On the other hand this works, but only by chance:
 ```{r}


### PR DESCRIPTION
Just a couple of small typos I noticed while going through the training up to the tidyverse stuff.

One thing I'm not sure of is in `00d_r_data-structure-index.Rmd` L156:

prior to this is:
```r
sequence_example <- seq(10)
head(sequence_example, n=2)
tail(sequence_example, n=4)
length(sequence_example)
str(sequence_example)
```
and the last output on the rendered page is:
`##  int [1:10] 1 2 3 4 5 6 7 8 9 10`

followed by:
```
The somewhat cryptic output from this command indicates the basic data type
found in this vector - in this case `chr`, character; an indication of the
number of things in the vector - actually, the indexes of the vector, in this
case `[1:3]`; and a few examples of what's actually in the vector - in this case
empty character strings.
```
which didn't seem to follow. However my 'correction' may not be right. Feel free to reject this..